### PR TITLE
fix(react-intl) use new locale-data imports for the languages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,11 +7,11 @@ import makeRoutes from './routes'
 import Root from './containers/Root'
 import configureStore from './redux/configureStore'
 import { addLocaleData } from 'react-intl'
-import en from 'react-intl/lib/locale-data/en'
-import de from 'react-intl/lib/locale-data/de'
-import it from 'react-intl/lib/locale-data/it'
-import es from 'react-intl/lib/locale-data/es'
-import fr from 'react-intl/lib/locale-data/fr'
+import en from 'react-intl/locale-data/en'
+import de from 'react-intl/locale-data/de'
+import it from 'react-intl/locale-data/it'
+import es from 'react-intl/locale-data/es'
+import fr from 'react-intl/locale-data/fr'
 
 // Configure history for react-router
 const browserHistory = useRouterHistory(createBrowserHistory)({


### PR DESCRIPTION
With the new version of react-intl, the locale data route has changed:
Instead of using `react-intl/lib/locale-data/en` the boilerplate should use `react-intl/locale-data/en` 
This causes the project to fail when running `npm run dev` giving errors like:

```
ERROR in ./src/main.js
Module not found: Error: Cannot resolve module 'react-intl/lib/locale-data/fr' in src
 @ ./src/main.js 49:10-50
```

This pull request changes the imports so the project can run with npm run dev
