### PR TITLE
Production deployed version now loads; hoisting fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,16 @@ addLocaleData(it)
 addLocaleData(es)
 addLocaleData(fr)
 
+function start () {
+  // Now that redux and react-router have been configured, we can render the
+  // React application to the DOM!
+
+  ReactDOM.render(
+    <Root history={history} routes={routes} store={store} />,
+    document.getElementById('root')
+  )
+}
+
 // All modern browsers, expect `Safari`, have implemented
 // the `ECMAScript Internationalization API`.
 // For that we need to patch in on runtime.
@@ -50,19 +60,3 @@ if (!global.Intl) {
 } else {
   start()
 }
-
-function start () {
-  // Render the React application to the DOM
-  ReactDOM.render(
-    <Root history={history} routes={routes} store={store} />,
-    document.getElementById('root')
-  )
-}
-
-// Now that redux and react-router have been configured, we can render the
-// React application to the DOM!
-
-ReactDOM.render(
-  <Root history={history} routes={routes} store={store} />,
-  document.getElementById('root')
-)


### PR DESCRIPTION
Currently, if you run

```
npm run deploy
NODE_ENV=production npm run start
```

the page will not render properly and will throw an error in the console:

> "Uncaught Error: Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings."

I would assume that function hoisting should operate as usual, meaning that the start function should get hoisted to the beginning of the scope and you should be able to call start() before defining it. This works when you set NODE_ENV=development. However, it seems that when using webpack with the production configuration (NODE_ENV=production), this doesn't work. start is undefined when attempting to invoke it as a function.

I've submitted this PR as a temporary workaround, in the meantime I am very curious as to which webpack config is causing this issue.
